### PR TITLE
feat: add servlet context path support for notifications service

### DIFF
--- a/services/graphiql/src/main/java/org/activiti/cloud/services/notifications/graphql/graphiql/GraphiQLConfigController.java
+++ b/services/graphiql/src/main/java/org/activiti/cloud/services/notifications/graphql/graphiql/GraphiQLConfigController.java
@@ -22,13 +22,17 @@ public class GraphiQLConfigController {
 	@Value("${graphiql.graphql.ws.path:/ws/graphql}")
 	private String graphqlWsPath;
 
+    @Value("${server.servlet.context-path:}")
+    private String contextPath;
+    
+	
     @GetMapping(value="graphiql/config.js",  produces = "application/javascript")
     @ResponseStatus(HttpStatus.OK)
     public String getConfigJs() {
     	
     	String config = "window.GraphqlApi = {" +
-    			"   graphqlWebPath: " + "\"" + graphqlWebPath + "\"," +
-    			"   graphqlWsPath: " + "\"" + graphqlWsPath + "\"" +
+    			"   graphqlWebPath: " + "\"" + getGraphQLWebPath() + "\"," +
+    			"   graphqlWsPath: " + "\"" + getGraphQLWsPath() + "\"" +
     			"}";    	
     	
         return config;
@@ -38,10 +42,34 @@ public class GraphiQLConfigController {
     public ResponseEntity<Map<String, Object>> getGraphiqlJson() {
         Map<String, Object> values = new LinkedHashMap<>();
         
-        values.put("graphqlWebPath", graphqlWebPath);
-        values.put("graphqlWsPath", graphqlWsPath);
+        values.put("graphqlWebPath", getGraphQLWebPath());
+        values.put("graphqlWsPath", getGraphQLWsPath());
         
         return ResponseEntity.ok(values);
-    }	
+    }
+    
+    public String getGraphQLWebPath() {
+        return appendSegmentToPath(contextPath, graphqlWebPath);
+    }
+
+    public String getGraphQLWsPath() {
+        return appendSegmentToPath(contextPath, graphqlWsPath);
+    }
+    
+    public String appendSegmentToPath(String path, String segment) {
+        if (path == null || path.isEmpty() || "/".equals(path)) {
+            return segment;
+        }
+        
+        if(path.endsWith("/")) {
+            path = path.substring(0,path.length()-1);
+        }
+
+        if (segment.startsWith("/")) {
+            return path + segment;
+        }
+
+        return path + "/" + segment;
+    }    
     
 }

--- a/services/graphiql/src/test/java/org/activiti/cloud/services/notifications/graphql/graphiql/GraphiQLAutoConfigurationTest.java
+++ b/services/graphiql/src/test/java/org/activiti/cloud/services/notifications/graphql/graphiql/GraphiQLAutoConfigurationTest.java
@@ -31,6 +31,10 @@ public class GraphiQLAutoConfigurationTest {
     @Autowired
     private KeycloakJsonController keycloakJsonController;
 
+    @Autowired
+    private GraphiQLConfigController graphiQLConfigController;
+    
+    
     @SpringBootApplication
     static class Application {
         // 
@@ -38,7 +42,20 @@ public class GraphiQLAutoConfigurationTest {
     
     @Test
     public void contextLoads() {
-        assertThat(keycloakJsonController).isNotNull();
+        assertThat(keycloakJsonController.get().getBody()).isNotNull();
+        assertThat(graphiQLConfigController.getGraphQLWebPath()).isEqualTo("/default-app/graphql");
+        assertThat(graphiQLConfigController.getGraphQLWsPath()).isEqualTo("/default-app/ws/graphql");
     }
 
+    @Test
+    public void testContextPath() {
+        assertThat(graphiQLConfigController.appendSegmentToPath("","/graphql")).isEqualTo("/graphql");
+        assertThat(graphiQLConfigController.appendSegmentToPath("/","/graphql")).isEqualTo("/graphql");
+        assertThat(graphiQLConfigController.appendSegmentToPath(null,"/graphql")).isEqualTo("/graphql");
+        assertThat(graphiQLConfigController.appendSegmentToPath("/default-app","/graphql")).isEqualTo("/default-app/graphql");
+        assertThat(graphiQLConfigController.appendSegmentToPath("/default-app/","/graphql")).isEqualTo("/default-app/graphql");
+        assertThat(graphiQLConfigController.appendSegmentToPath("/default-app","graphql")).isEqualTo("/default-app/graphql");
+    }
+    
+    
 }

--- a/services/graphiql/src/test/resources/application.properties
+++ b/services/graphiql/src/test/resources/application.properties
@@ -2,3 +2,5 @@ keycloak.auth-server-url=http://localhost:8180/auth
 keycloak.realm=activiti
 keycloak.resource=activiti
 keycloak.public-client=true
+
+server.servlet.context-path=/default-app


### PR DESCRIPTION
This PR adds  support for lifting server servlet context path via Spring Boot configuration property `server.servlet.context-path` or environment variable `SERVER_SERVLET_CONTEXTPATH`

Fixes https://github.com/Activiti/Activiti/issues/2543