### PR TITLE
fix(versions): update graphql-jpa-query dependencies to 0.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       <activiti-cloud-build.version>7.1.7</activiti-cloud-build.version>
       <activiti-cloud-query-service.version>7.1.37</activiti-cloud-query-service.version>
       <activiti-cloud-notifications-service-graphql.version>${project.version}</activiti-cloud-notifications-service-graphql.version>
-      <graphql-jpa-query.version>0.3.11</graphql-jpa-query.version>
+      <graphql-jpa-query.version>0.3.20</graphql-jpa-query.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This PR updates graphql-jpa-query dependencies to 0.3.20 

Graphql-jpa-query 0.3.20 contains the following improvements and bug fixes since 0.3.11:

feat: support nested relationships in where criteria expressions (#108) b05c246
feat: add LOCATE predicate for JPA entity attributes annotated with @convert (#115) 3f9704b
feat: support enum variable bindings in queries (#109) 5dd999a
fix: NullPointerException when searching for Transient annotation (#106) fb45d23
feat: Enable/Disable distinct Sql select and ignore field in filters and sorting (#95) bde04d5
feat: add where relation attributes criteria expressions (#96) b296d8a
fix: use embeddableType javaType to cache corresponding GraphQL type (#98) ce4f85a
feat: Support calculated fields and functions via @Transient annotation mapping (#85) 1cbf29c
feat: add JPA @EmbeddedId support (#84) 0def68d
fix: change ExecutionResult to return Map type using toSpecification() (#71) 556afe6
feat: BETWEEN and NOT_BETWEEN where criterias (#69) 007014b
fix: Add Missing LocalTime Coercing (#68) d576bab
fix: Enable variable mapping to page arguments (#67) 3f313bd

See https://github.com/introproventures/graphql-jpa-query/releases