### PR TITLE
fix(versions): update graphql-jpa-query dependencies to 0.3.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       <activiti-cloud-build.version>7.1.7</activiti-cloud-build.version>
       <activiti-cloud-query-service.version>7.1.38</activiti-cloud-query-service.version>
       <activiti-cloud-notifications-service-graphql.version>${project.version}</activiti-cloud-notifications-service-graphql.version>
-      <graphql-jpa-query.version>0.3.24</graphql-jpa-query.version>
+      <graphql-jpa-query.version>0.3.25</graphql-jpa-query.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       <activiti-cloud-build.version>7.1.7</activiti-cloud-build.version>
       <activiti-cloud-query-service.version>7.1.38</activiti-cloud-query-service.version>
       <activiti-cloud-notifications-service-graphql.version>${project.version}</activiti-cloud-notifications-service-graphql.version>
-      <graphql-jpa-query.version>0.3.20</graphql-jpa-query.version>
+      <graphql-jpa-query.version>0.3.24</graphql-jpa-query.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This PR updates graphql-jpa-query dependencies to 0.3.25 containing:

fix: Let's not pass DISTINCT in JPQL for better performance 4a75979
fix: Let's pass and apply distinct in query results if enabled (#124) dcb037b
fix: lets fetch element collection attributes (#123) ca7f78e
fix: Apply left outer join to retrieve optional associations [WIP] (#105) 7ff25ae
fix: compound nested relationship criteria expressions (#121) af279d9
Fix MappedSuperclass for JPA entity attributes (#120) c67073a

See for details: https://github.com/introproventures/graphql-jpa-query/releases