### PR TITLE
feat: Support PROCESS_DEPLOYED & SIGNAL_RECEIVED subscriptions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
           branch "PR-*"
         }
         environment {
-          PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+          PREVIEW_VERSION = "7.1.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
           PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
           HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
         }
@@ -23,6 +23,10 @@ pipeline {
           container("maven") {
             sh "mvn versions:set -DnewVersion=${PREVIEW_VERSION}"
             sh "mvn install"
+            
+            // deploy preview to Alfresco Activiti Maven repository
+            sh 'mvn clean deploy -DskipTests'
+            
           }
         }
       }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       <activiti-cloud-build.version>7.1.7</activiti-cloud-build.version>
       <activiti-cloud-query-service.version>7.1.47</activiti-cloud-query-service.version>
       <activiti-cloud-notifications-service-graphql.version>${project.version}</activiti-cloud-notifications-service-graphql.version>
-      <graphql-jpa-query.version>0.3.25</graphql-jpa-query.version>
+      <graphql-jpa-query.version>0.3.27</graphql-jpa-query.version>
   </properties>
 
   <dependencyManagement>

--- a/services/api/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/api/GraphQLMessage.java
+++ b/services/api/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/api/GraphQLMessage.java
@@ -19,8 +19,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-import javax.annotation.Generated;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -31,7 +29,6 @@ public class GraphQLMessage {
 	private String id;
 	private GraphQLMessageType type;
 
-    @Generated("SparkTools")
     private GraphQLMessage(Builder builder) {
         this.type = builder.type;
         this.id = builder.id;
@@ -95,18 +92,15 @@ public class GraphQLMessage {
      * Creates builder to build {@link GraphQLMessage}.
      * @return created builder
      */
-    @Generated("SparkTools")
     public static ITypeStage builder() {
         return new Builder();
     }
 
-    @Generated("SparkTools")
     public interface ITypeStage {
 
         public IBuildStage type(GraphQLMessageType type);
     }
 
-    @Generated("SparkTools")
     public interface IBuildStage {
 
         public IBuildStage id(String id);
@@ -119,7 +113,6 @@ public class GraphQLMessage {
     /**
      * Builder to build {@link GraphQLMessage}.
      */
-    @Generated("SparkTools")
     public static final class Builder implements ITypeStage, IBuildStage {
 
         private GraphQLMessageType type;

--- a/services/api/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/api/GraphQLMessage.java
+++ b/services/api/src/main/java/org/activiti/cloud/services/notifications/graphql/ws/api/GraphQLMessage.java
@@ -19,13 +19,26 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(value = Include.ALWAYS)
 public class GraphQLMessage {
 
 	private Map<String, Object> payload;
 	private String id;
 	private GraphQLMessageType type;
 
-	GraphQLMessage() {
+    @Generated("SparkTools")
+    private GraphQLMessage(Builder builder) {
+        this.type = builder.type;
+        this.id = builder.id;
+        this.payload = builder.payload;
+    }
+
+    GraphQLMessage() {
 	}
 	
     public GraphQLMessage(String id, GraphQLMessageType type) {
@@ -77,5 +90,69 @@ public class GraphQLMessage {
         sb.append(", type=").append(this.type).append("]");
 		return sb.toString();
 	}
+
+    /**
+     * Creates builder to build {@link GraphQLMessage}.
+     * @return created builder
+     */
+    @Generated("SparkTools")
+    public static ITypeStage builder() {
+        return new Builder();
+    }
+
+    @Generated("SparkTools")
+    public interface ITypeStage {
+
+        public IBuildStage type(GraphQLMessageType type);
+    }
+
+    @Generated("SparkTools")
+    public interface IBuildStage {
+
+        public IBuildStage id(String id);
+
+        public IBuildStage payload(Map<String, Object> payload);
+
+        public GraphQLMessage build();
+    }
+
+    /**
+     * Builder to build {@link GraphQLMessage}.
+     */
+    @Generated("SparkTools")
+    public static final class Builder implements ITypeStage, IBuildStage {
+
+        private GraphQLMessageType type;
+        private String id;
+        private Map<String, Object> payload = Collections.emptyMap();
+
+        private Builder() {
+        }
+
+        @Override
+        public IBuildStage type(GraphQLMessageType type) {
+            this.type = type;
+            return this;
+        }
+
+        @Override
+        public IBuildStage id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        @Override
+        public IBuildStage payload(Map<String, Object> payload) {
+            this.payload = payload;
+            return this;
+        }
+
+        @Override
+        public GraphQLMessage build() {
+            return new GraphQLMessage(this);
+        }
+    }
+
+
 
 }

--- a/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/GraphQLSubscriptionSchemaBuilder.java
+++ b/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/GraphQLSubscriptionSchemaBuilder.java
@@ -50,8 +50,9 @@ public class GraphQLSubscriptionSchemaBuilder {
             throw new RuntimeException(cause);
         }
         this.typeRegistry = new SchemaParser().parse(streamReader);
-        this.wiring = RuntimeWiring.newRuntimeWiring();
-
+        
+        this.wiring = RuntimeWiring.newRuntimeWiring()
+                                   .scalar(new ObjectScalar());
    }
 
     private GraphQLSchema buildSchema() {

--- a/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/ObjectScalar.java
+++ b/services/subscriptions/src/main/java/org/activiti/cloud/services/notifications/graphql/subscriptions/ObjectScalar.java
@@ -1,0 +1,100 @@
+package org.activiti.cloud.services.notifications.graphql.subscriptions;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import graphql.Assert;
+import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
+import graphql.language.EnumValue;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.NullValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.language.VariableReference;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+
+public class ObjectScalar extends GraphQLScalarType {
+
+
+    public ObjectScalar() {
+        this("ObjectScalar", "An object scalar");
+    }
+
+    ObjectScalar(String name, String description) {
+        super(name, description, new Coercing<Object, Object>() {
+            @Override
+            public Object serialize(Object input) throws CoercingSerializeException {
+                return input;
+            }
+
+            @Override
+            public Object parseValue(Object input) throws CoercingParseValueException {
+                return input;
+            }
+
+            @Override
+            public Object parseLiteral(Object input) throws CoercingParseLiteralException {
+                return parseLiteral(input, Collections.emptyMap());
+            }
+
+            @Override
+            public Object parseLiteral(Object input, Map<String, Object> variables) throws CoercingParseLiteralException {
+                if (!(input instanceof Value)) {
+                    throw new CoercingParseLiteralException(
+                            "Expected AST type 'StringValue' but was '" + input + "'."
+                    );
+                }
+                if (input instanceof NullValue) {
+                    return null;
+                }
+                if (input instanceof FloatValue) {
+                    return ((FloatValue) input).getValue();
+                }
+                if (input instanceof StringValue) {
+                    return ((StringValue) input).getValue();
+                }
+                if (input instanceof IntValue) {
+                    return ((IntValue) input).getValue();
+                }
+                if (input instanceof BooleanValue) {
+                    return ((BooleanValue) input).isValue();
+                }
+                if (input instanceof EnumValue) {
+                    return ((EnumValue) input).getName();
+                }
+                if (input instanceof VariableReference) {
+                    String varName = ((VariableReference) input).getName();
+                    return variables.get(varName);
+                }
+                if (input instanceof ArrayValue) {
+                    List<Value> values = ((ArrayValue) input).getValues();
+                    return values.stream()
+                            .map(v -> parseLiteral(v, variables))
+                            .collect(Collectors.toList());
+                }
+                if (input instanceof ObjectValue) {
+                    List<ObjectField> values = ((ObjectValue) input).getObjectFields();
+                    Map<String, Object> parsedValues = new LinkedHashMap<>();
+                    values.forEach(fld -> {
+                        Object parsedValue = parseLiteral(fld.getValue(), variables);
+                        parsedValues.put(fld.getName(), parsedValue);
+                    });
+                    return parsedValues;
+                }
+                return Assert.assertShouldNeverHappen("We have covered all Value types");
+            }
+        });
+    }
+
+}

--- a/services/subscriptions/src/main/resources/activiti.graphqls
+++ b/services/subscriptions/src/main/resources/activiti.graphqls
@@ -17,7 +17,7 @@ type Subscription {
     	serviceName : String, 
     	appName : String, 
     	processDefinitionKey : String,
-		processInstanceId : String. 
+		processInstanceId : String, 
 		businessKey : String
     ) : ProcessEngineNotification
 }
@@ -84,6 +84,13 @@ type PROCESS_RESUMED {
     timestamp : Long
     entity : ProcessInstanceType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type PROCESS_SUSPENDED {
@@ -99,6 +106,13 @@ type PROCESS_SUSPENDED {
     timestamp : Long
     entity : ProcessInstanceType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type PROCESS_STARTED {
@@ -116,7 +130,14 @@ type PROCESS_STARTED {
     eventType : String
     
     nestedProcessDefinitionId : String
-    nestedProcessInstanceId : String    
+    nestedProcessInstanceId : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type PROCESS_COMPLETED {
@@ -132,6 +153,13 @@ type PROCESS_COMPLETED {
     timestamp : Long
     entity : ProcessInstanceType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type PROCESS_CREATED {
@@ -147,6 +175,13 @@ type PROCESS_CREATED {
     timestamp : Long
     entity : ProcessInstanceType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type PROCESS_CANCELLED {
@@ -164,6 +199,13 @@ type PROCESS_CANCELLED {
     eventType : String
 
     cause: String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type BPMNActivityType {
@@ -187,6 +229,13 @@ type ACTIVITY_COMPLETED {
     timestamp : Long
     entity : BPMNActivityType
     eventType : String
+
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type ACTIVITY_STARTED {
@@ -202,6 +251,13 @@ type ACTIVITY_STARTED {
     timestamp : Long
     entity : BPMNActivityType
     eventType : String
+
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type ACTIVITY_CANCELLED {
@@ -219,6 +275,13 @@ type ACTIVITY_CANCELLED {
     eventType : String
 
     cause: String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type VariableInstance {
@@ -244,6 +307,13 @@ type VARIABLE_CREATED {
     timestamp : Long
     entity : VariableInstance
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type VARIABLE_DELETED {
@@ -259,6 +329,13 @@ type VARIABLE_DELETED {
     timestamp : Long
     entity : VariableInstance
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type VARIABLE_UPDATED {
@@ -274,6 +351,13 @@ type VARIABLE_UPDATED {
     timestamp : Long
     entity : VariableInstance
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 
@@ -301,6 +385,13 @@ type SEQUENCE_FLOW_TAKEN {
     timestamp : Long
     entity : SequenceFlowType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TaskType {
@@ -332,6 +423,13 @@ type TASK_CREATED {
     timestamp : Long
     entity : TaskType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TASK_SUSPENDED {
@@ -347,6 +445,13 @@ type TASK_SUSPENDED {
     timestamp : Long
     entity : TaskType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TASK_STARTED {
@@ -362,6 +467,13 @@ type TASK_STARTED {
     timestamp : Long
     entity : TaskType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TASK_ACTIVATED {
@@ -377,6 +489,13 @@ type TASK_ACTIVATED {
     timestamp : Long
     entity : TaskType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TASK_ASSIGNED {
@@ -392,6 +511,13 @@ type TASK_ASSIGNED {
     timestamp : Long
     entity : TaskType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TASK_COMPLETED {
@@ -407,6 +533,13 @@ type TASK_COMPLETED {
     timestamp : Long
     entity : TaskType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TASK_CANCELLED {
@@ -424,14 +557,25 @@ type TASK_CANCELLED {
     eventType : String
     
     cause: String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 
 type IntegrationContextType {
     id : String
     processInstanceId : String
+    parentProcessInstanceId : String
     processDefinitionId : String
+    processDefinitionVersion : Long
+    processDefinitionKey : String
     connectorType : String
+    businessKey: String
     activityElementId : String
     inBoundVariables : ObjectScalar
     outBoundVariables : ObjectScalar
@@ -451,6 +595,13 @@ type INTEGRATION_REQUESTED {
     timestamp : Long
     entity : IntegrationContextType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type INTEGRATION_RESULT_RECEIVED {
@@ -466,6 +617,13 @@ type INTEGRATION_RESULT_RECEIVED {
     timestamp : Long
     entity : IntegrationContextType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TaskCandidateUserType {
@@ -486,6 +644,13 @@ type TASK_CANDIDATE_USER_ADDED {
     timestamp : Long
     entity : TaskCandidateUserType
     eventType : String
+    
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TASK_CANDIDATE_USER_REMOVED {
@@ -501,6 +666,13 @@ type TASK_CANDIDATE_USER_REMOVED {
     timestamp : Long
     entity : TaskCandidateUserType
     eventType : String
+
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 
@@ -522,6 +694,13 @@ type TASK_CANDIDATE_GROUP_ADDED {
     timestamp : Long
     entity : TaskCandidateGroupType
     eventType : String
+
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type TASK_CANDIDATE_GROUP_REMOVED {
@@ -537,6 +716,13 @@ type TASK_CANDIDATE_GROUP_REMOVED {
     timestamp : Long
     entity : TaskCandidateGroupType
     eventType : String
+
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
 }
 
 type PROCESS_DEPLOYED {

--- a/services/subscriptions/src/main/resources/activiti.graphqls
+++ b/services/subscriptions/src/main/resources/activiti.graphqls
@@ -34,6 +34,7 @@ type ProcessEngineNotification {
 	PROCESS_CANCELLED : [PROCESS_CANCELLED]
 	PROCESS_RESUMED : [PROCESS_RESUMED]
 	PROCESS_SUSPENDED : [PROCESS_SUSPENDED]
+	PROCESS_DEPLOYED : [PROCESS_DEPLOYED]
 	ACTIVITY_STARTED : [ACTIVITY_STARTED]
 	ACTIVITY_CANCELLED : [ACTIVITY_CANCELLED]
 	ACTIVITY_COMPLETED : [ACTIVITY_COMPLETED]
@@ -537,4 +538,36 @@ type TASK_CANDIDATE_GROUP_REMOVED {
     eventType : String
 }
 
+type PROCESS_DEPLOYED {
+    serviceName : String
+    serviceFullName : String
+    serviceVersion : String
+    serviceType : String
+    appName : String
+    appVersion : String
+    entityId : String
+
+    id : String
+    timestamp : Long
+    entity : ProcessDefinitionType
+    eventType : String
+    
+    processModelContent: String    
+
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
+}
+
+type ProcessDefinitionType {
+    id : String
+    name : String
+    key : String
+    description : String
+    version : Long
+    formKey : String
+}
 

--- a/services/subscriptions/src/main/resources/activiti.graphqls
+++ b/services/subscriptions/src/main/resources/activiti.graphqls
@@ -54,6 +54,7 @@ type ProcessEngineNotification {
 	TASK_CANDIDATE_USER_REMOVED: [TASK_CANDIDATE_USER_REMOVED]
 	TASK_CANDIDATE_GROUP_ADDED: [TASK_CANDIDATE_GROUP_ADDED]
 	TASK_CANDIDATE_GROUP_REMOVED: [TASK_CANDIDATE_GROUP_REMOVED]
+	SIGNAL_RECEIVED: [SIGNAL_RECEIVED]
 }
 
 type ProcessInstanceType {
@@ -571,3 +572,35 @@ type ProcessDefinitionType {
     formKey : String
 }
 
+type SignalPayloadType {
+    elementId : String
+    processInstanceId : String
+    processDefinitionId : String
+    
+    id :  String
+    name : String
+    variables : ObjectScalar
+}
+
+type SIGNAL_RECEIVED {
+    serviceName : String
+    serviceFullName : String
+    serviceVersion : String
+    serviceType : String
+    appName : String
+    appVersion : String
+    entityId : String
+
+    id : String
+    timestamp : Long
+    entity : SignalPayloadType
+    eventType : String
+
+    processInstanceId : String
+    parentProcessInstanceId : String
+    processDefinitionId : String
+    processDefinitionKey : String
+    processDefinitionVersion : Long
+    businessKey String
+
+}

--- a/services/subscriptions/src/main/resources/activiti.graphqls
+++ b/services/subscriptions/src/main/resources/activiti.graphqls
@@ -90,7 +90,7 @@ type PROCESS_RESUMED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type PROCESS_SUSPENDED {
@@ -112,7 +112,7 @@ type PROCESS_SUSPENDED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type PROCESS_STARTED {
@@ -137,7 +137,7 @@ type PROCESS_STARTED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type PROCESS_COMPLETED {
@@ -159,7 +159,7 @@ type PROCESS_COMPLETED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type PROCESS_CREATED {
@@ -181,7 +181,7 @@ type PROCESS_CREATED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type PROCESS_CANCELLED {
@@ -205,7 +205,7 @@ type PROCESS_CANCELLED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type BPMNActivityType {
@@ -235,7 +235,7 @@ type ACTIVITY_COMPLETED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type ACTIVITY_STARTED {
@@ -257,7 +257,7 @@ type ACTIVITY_STARTED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type ACTIVITY_CANCELLED {
@@ -281,7 +281,7 @@ type ACTIVITY_CANCELLED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type VariableInstance {
@@ -313,7 +313,7 @@ type VARIABLE_CREATED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type VARIABLE_DELETED {
@@ -335,7 +335,7 @@ type VARIABLE_DELETED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type VARIABLE_UPDATED {
@@ -357,7 +357,7 @@ type VARIABLE_UPDATED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 
@@ -391,7 +391,7 @@ type SEQUENCE_FLOW_TAKEN {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TaskType {
@@ -429,7 +429,7 @@ type TASK_CREATED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TASK_SUSPENDED {
@@ -451,7 +451,7 @@ type TASK_SUSPENDED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TASK_STARTED {
@@ -473,7 +473,7 @@ type TASK_STARTED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TASK_ACTIVATED {
@@ -495,7 +495,7 @@ type TASK_ACTIVATED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TASK_ASSIGNED {
@@ -517,7 +517,7 @@ type TASK_ASSIGNED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TASK_COMPLETED {
@@ -539,7 +539,7 @@ type TASK_COMPLETED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TASK_CANCELLED {
@@ -563,7 +563,7 @@ type TASK_CANCELLED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 
@@ -601,7 +601,7 @@ type INTEGRATION_REQUESTED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type INTEGRATION_RESULT_RECEIVED {
@@ -623,7 +623,7 @@ type INTEGRATION_RESULT_RECEIVED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TaskCandidateUserType {
@@ -650,7 +650,7 @@ type TASK_CANDIDATE_USER_ADDED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TASK_CANDIDATE_USER_REMOVED {
@@ -672,7 +672,7 @@ type TASK_CANDIDATE_USER_REMOVED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 
@@ -700,7 +700,7 @@ type TASK_CANDIDATE_GROUP_ADDED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type TASK_CANDIDATE_GROUP_REMOVED {
@@ -722,7 +722,7 @@ type TASK_CANDIDATE_GROUP_REMOVED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type PROCESS_DEPLOYED {
@@ -746,7 +746,7 @@ type PROCESS_DEPLOYED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 }
 
 type ProcessDefinitionType {
@@ -787,6 +787,6 @@ type SIGNAL_RECEIVED {
     processDefinitionId : String
     processDefinitionKey : String
     processDefinitionVersion : Long
-    businessKey String
+    businessKey : String
 
 }

--- a/services/subscriptions/src/main/resources/activiti.graphqls
+++ b/services/subscriptions/src/main/resources/activiti.graphqls
@@ -1,6 +1,8 @@
 #
 # Schemas must have at least a query root type
 #
+scalar ObjectScalar
+
 schema {
     query: Query
     subscription : Subscription
@@ -223,7 +225,7 @@ type VariableInstance {
     processInstanceId : String
     taskId : String
     taskVariable : Boolean
-    value : String
+    value : ObjectScalar
 }
 
 
@@ -429,8 +431,8 @@ type IntegrationContextType {
     processDefinitionId : String
     connectorType : String
     activityElementId : String
-    inBoundVariables : String
-    outBoundVariables : String    
+    inBoundVariables : ObjectScalar
+    outBoundVariables : ObjectScalar
 }
 
 

--- a/services/subscriptions/src/main/resources/activiti.graphqls
+++ b/services/subscriptions/src/main/resources/activiti.graphqls
@@ -23,11 +23,6 @@ type Subscription {
 }
 
 type ProcessEngineNotification {
-	serviceName : String
-	appName : String 
-	processDefinitionKey : String 
-	processInstanceId : String 
-	businessKey : String 
 	PROCESS_STARTED : [PROCESS_STARTED]
 	PROCESS_COMPLETED : [PROCESS_COMPLETED]
 	PROCESS_CREATED : [PROCESS_CREATED]

--- a/services/subscriptions/src/test/java/org/activiti/cloud/services/notifications/graphql/subscriptions/ObjectScalarTest.java
+++ b/services/subscriptions/src/test/java/org/activiti/cloud/services/notifications/graphql/subscriptions/ObjectScalarTest.java
@@ -1,0 +1,126 @@
+package org.activiti.cloud.services.notifications.graphql.subscriptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
+import graphql.language.EnumValue;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.NullValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.language.VariableReference;
+import graphql.schema.Coercing;
+import org.junit.Test;
+
+public class ObjectScalarTest {
+
+    private Map<String, Object> variables = Collections.singletonMap( "varRef1", "value1");
+
+    private Coercing<?,?> coercing = new ObjectScalar().getCoercing();
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testASTParsing() {
+        // when
+        assertThat(coercing.parseLiteral(mkStringValue("s"), variables)).isEqualTo("s");
+        assertThat(coercing.parseLiteral(mkFloatValue("99.9"), variables)).isEqualTo(new BigDecimal("99.9"));
+        assertThat(coercing.parseLiteral(mkIntValue(BigInteger.valueOf(666)), variables)).isEqualTo(BigInteger.valueOf(666));
+        assertThat(coercing.parseLiteral(mkBooleanValue(true), variables)).isEqualTo(true);
+        assertThat(coercing.parseLiteral(mkNullValue(), variables)).isEqualTo(null);
+        assertThat(coercing.parseLiteral(mkVarRef("varRef1"), variables)).isEqualTo("value1");
+        assertThat(coercing.parseLiteral(mkArrayValue(new ArrayList<Value>() {{ add(mkStringValue("s")); add(mkIntValue(BigInteger.valueOf(666))); }}), variables))
+                            .asList()
+                            .containsExactly("s",BigInteger.valueOf(666));
+         
+    }
+
+    @SuppressWarnings({"serial", "rawtypes"})
+    @Test
+    public void testASTObjectParsing() {
+        Map<String, Value> input = new LinkedHashMap<String, Value>();
+        
+        input.put("fld1", mkStringValue("s"));
+        input.put("fld2", mkIntValue(BigInteger.valueOf(666)));
+        input.put("fld3", mkObjectValue(new LinkedHashMap<String, Value>() {{ 
+            put("childFld1", mkStringValue("child1"));
+            put("childFl2", mkVarRef("varRef1"));
+        }}));
+
+
+        Map<String, Object> expected = new LinkedHashMap<String, Object>();
+        
+        expected.put("fld1", "s");
+        expected.put("fld2", BigInteger.valueOf(666));
+        expected.put("fld3", new LinkedHashMap<String, Object>() {{ 
+            put("childFld1", "child1");
+            put("childFl2", "value1");
+        }});
+        
+        assertThat(coercing.parseLiteral(mkObjectValue(input), variables)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testSerializeIsAlwaysInAndOut() {
+        assertThat(coercing.serialize(666)).isEqualTo(666);
+        assertThat(coercing.serialize("same")).isEqualTo("same");
+    }
+
+    @Test
+    public void testParseValueIsAlwaysInAndOut() {
+        assertThat(coercing.parseValue(666)).isEqualTo(666);
+        assertThat(coercing.parseValue("same")).isEqualTo("same");
+    }
+
+    ObjectValue mkObjectValue(Map<String, Value> fields) {
+        List<ObjectField> list = new ArrayList<>();
+        
+        for (String key : fields.keySet()) {
+            list.add(new ObjectField(key, fields.get(key)));
+        }
+        return new ObjectValue(list);
+    }
+
+    VariableReference mkVarRef(String name) {
+        return new VariableReference(name);
+    }
+
+    ArrayValue mkArrayValue(List<Value> values) {
+        return new ArrayValue(values);
+    }
+
+    NullValue mkNullValue() {
+        return NullValue.newNullValue().build();
+    }
+
+    EnumValue mkEnumValue(String val) {
+        return new EnumValue(val);
+    }
+
+    BooleanValue mkBooleanValue(boolean val) {
+        return new BooleanValue(val);
+    }
+
+    IntValue mkIntValue(BigInteger val) {
+        return new IntValue(val);
+    }
+
+    FloatValue mkFloatValue(String val) {
+        return new FloatValue(new BigDecimal(val));
+    }
+
+    StringValue mkStringValue(String val) {
+        return new StringValue(val);
+    }
+}

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -32,6 +32,10 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud.notifications.graphql</groupId>
+      <artifactId>activiti-cloud-services-notifications-graphql-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud.notifications.graphql</groupId>
       <artifactId>activiti-cloud-services-notifications-graphql-schema</artifactId>
     </dependency>
     <dependency>
@@ -138,6 +142,21 @@
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency> 
+      <groupId>org.activiti.cloud.api</groupId> 
+      <artifactId>activiti-cloud-api-model-shared-impl</artifactId>     
+      <scope>test</scope>
+    </dependency>     
+    <dependency> 
+      <groupId>org.activiti.cloud.api</groupId> 
+      <artifactId>activiti-cloud-api-process-model-impl</artifactId>     
+      <scope>test</scope>
+    </dependency>   
+    <dependency> 
+      <groupId>org.activiti.cloud.api</groupId> 
+      <artifactId>activiti-cloud-api-task-model-impl</artifactId>     
+      <scope>test</scope>
+    </dependency>      
   </dependencies>
   <profiles>
     <profile>

--- a/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
+++ b/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
@@ -193,8 +193,6 @@ public class ActivitiGraphQLStarterIT {
          
         Map<String, Object> payload = new StringObjectMapBuilder().put("query", "subscription($appName: String!) { "
                                                                                 + "  engineEvents(appName: $appName) { "
-                                                                                + "    appName "
-                                                                                + "    serviceName "
                                                                                 + "    PROCESS_CREATED { processInstanceId } "
                                                                                 + "    PROCESS_STARTED { processInstanceId } "
                                                                                 + "  } "
@@ -273,9 +271,7 @@ public class ActivitiGraphQLStarterIT {
         // then        
         Map<String, Object> message = Collections.singletonMap("data",
                                          Collections.singletonMap("engineEvents",
-                                              mapBuilder().put("appName", "default-app")
-                                                          .put("serviceName", "rb-my-app")
-                                                          .put("PROCESS_CREATED", Arrays.array(Collections.singletonMap("processInstanceId", "processInstanceId")))
+                                              mapBuilder().put("PROCESS_CREATED", Arrays.array(Collections.singletonMap("processInstanceId", "processInstanceId")))
                                                           .put("PROCESS_STARTED", Arrays.array(Collections.singletonMap("processInstanceId", "processInstanceId")))
                                                           .get())
                                       );
@@ -303,8 +299,6 @@ public class ActivitiGraphQLStarterIT {
          
         Map<String, Object> payload = new StringObjectMapBuilder().put("query", "subscription($appName: String!) { "
                                                                                 + "  engineEvents(appName: $appName) { "
-                                                                                + "    appName "
-                                                                                + "    serviceName "
                                                                                 + "    PROCESS_DEPLOYED { "
                                                                                 + "      processDefinitionKey "
                                                                                 + "      processModelContent "
@@ -369,9 +363,7 @@ public class ActivitiGraphQLStarterIT {
         // then        
         Map<String, Object> message = Collections.singletonMap("data",
                                          Collections.singletonMap("engineEvents",
-                                              mapBuilder().put("appName", "default-app")
-                                                          .put("serviceName", "rb-my-app")
-                                                          .put("PROCESS_DEPLOYED", Arrays.array(mapBuilder().put("processDefinitionKey", "processDefinitionKey")
+                                              mapBuilder().put("PROCESS_DEPLOYED", Arrays.array(mapBuilder().put("processDefinitionKey", "processDefinitionKey")
                                                                                                             .put("processModelContent", "processModelContent")
                                                                                                             .get()))
                                                           .get())
@@ -401,8 +393,6 @@ public class ActivitiGraphQLStarterIT {
          
         Map<String, Object> payload = new StringObjectMapBuilder().put("query", "subscription($appName: String!) { "
                                                                                 + "  engineEvents(appName: $appName) { "
-                                                                                + "    appName "
-                                                                                + "    serviceName "
                                                                                 + "    SIGNAL_RECEIVED { "
                                                                                 + "      processInstanceId "
                                                                                 + "      processDefinitionId "
@@ -470,9 +460,7 @@ public class ActivitiGraphQLStarterIT {
         // then        
         Map<String, Object> message = Collections.singletonMap("data",
                                          Collections.singletonMap("engineEvents",
-                                              mapBuilder().put("appName", "default-app")
-                                                          .put("serviceName", "rb-my-app")
-                                                          .put("SIGNAL_RECEIVED", Arrays.array(mapBuilder().put("processInstanceId", "processInstanceId")
+                                              mapBuilder().put("SIGNAL_RECEIVED", Arrays.array(mapBuilder().put("processInstanceId", "processInstanceId")
                                                                                                            .put("processDefinitionId", "processDefinitionId")
                                                                                                            .get()))
                                                           .get())


### PR DESCRIPTION
This PR fixes https://github.com/Activiti/Activiti/issues/2721:

- feat: add ObjectScalar type mapping for variables c8ce8af
- feat: add PROCESS_DEPLOYED subscription query field bdac6a5
- feat: add SIGNAL_RECEIVED subscription field b114980
- feat: add RuntimeEvent attributes to subscription fields e75021b
- feat: add ObjectScalar unit test 927ec1810ec4fc1705916004942bbf2d66a5c6de
- fix: filter events that do not match selections in the subscription 9fb464747b3d64bd453cc2f1ca3e0359da43e261
- fix: update graphql-jpa-query dependency version to 0.3.27
- feat: add GraphQLMessage api staged builder helper class
- feat: add PROCESS_DEPLOYED and SIGNAL_RECEIVED ITs
