### PR TITLE
refactor(build): removed component scan configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ after_failure:
   - cat **/target/surefire-reports/*.xml | grep -B 1 -A 10 "<error"
   - cat **/target/failsafe-reports/*.xml | grep -B 1 -A 10 "<error"
 
-env:
-  global:
-  - DOCKER_HOST=tcp://127.0.0.1:2375
+# env:
+#   global:
+#   - DOCKER_HOST=tcp://127.0.0.1:2375

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.activiti.cloud.build</groupId>
     <artifactId>activiti-cloud-parent</artifactId>
-    <version>7.1.10</version>
+    <version>7.1.11</version>
     <relativePath/>
   </parent>
 
@@ -17,7 +17,7 @@
   <url>http://activiti.org</url>
   
   <properties>
-      <activiti-cloud-build.version>7.1.10</activiti-cloud-build.version>
+      <activiti-cloud-build.version>7.1.11</activiti-cloud-build.version>
       <activiti-cloud-query-service.version>7.1.107</activiti-cloud-query-service.version>
       <activiti-cloud-notifications-service-graphql.version>${project.version}</activiti-cloud-notifications-service-graphql.version>
       <graphql-jpa-query.version>0.3.27</graphql-jpa-query.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   
   <properties>
       <activiti-cloud-build.version>7.1.11</activiti-cloud-build.version>
-      <activiti-cloud-query-service.version>7.1.107</activiti-cloud-query-service.version>
+      <activiti-cloud-query-service.version>7.1.108</activiti-cloud-query-service.version>
       <activiti-cloud-notifications-service-graphql.version>${project.version}</activiti-cloud-notifications-service-graphql.version>
       <graphql-jpa-query.version>0.3.27</graphql-jpa-query.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   
   <properties>
       <activiti-cloud-build.version>7.1.11</activiti-cloud-build.version>
-      <activiti-cloud-query-service.version>7.1.108</activiti-cloud-query-service.version>
+      <activiti-cloud-query-service.version>7.1.109</activiti-cloud-query-service.version>
       <activiti-cloud-notifications-service-graphql.version>${project.version}</activiti-cloud-notifications-service-graphql.version>
       <graphql-jpa-query.version>0.3.27</graphql-jpa-query.version>
   </properties>

--- a/services/events/pom.xml
+++ b/services/events/pom.xml
@@ -32,6 +32,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/services/graphiql/pom.xml
+++ b/services/graphiql/pom.xml
@@ -17,6 +17,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/services/jpa-query/pom.xml
+++ b/services/jpa-query/pom.xml
@@ -24,10 +24,6 @@
       <artifactId>activiti-cloud-services-notifications-graphql-schema</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -53,10 +49,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
@@ -79,6 +71,11 @@
     <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/schema/pom.xml
+++ b/services/schema/pom.xml
@@ -33,6 +33,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/security/pom.xml
+++ b/services/security/pom.xml
@@ -16,6 +16,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/services/subscriptions/pom.xml
+++ b/services/subscriptions/pom.xml
@@ -67,6 +67,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/web/pom.xml
+++ b/services/web/pom.xml
@@ -45,20 +45,15 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -88,6 +83,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -76,6 +76,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>

--- a/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
+++ b/starter/src/test/java/org/activiti/cloud/notifications/graphql/starter/ActivitiGraphQLStarterIT.java
@@ -17,17 +17,6 @@ package org.activiti.cloud.notifications.graphql.starter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.time.Duration;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeoutException;
-
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -80,11 +69,11 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -94,6 +83,17 @@ import reactor.netty.NettyPipeline;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClient.WebsocketSender;
 import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -126,8 +126,6 @@ public class ActivitiGraphQLStarterIT {
     private HttpHeaders authHeaders;
     
     @SpringBootApplication
-    @ComponentScan({"org.activiti.cloud.starters.test",
-                    "org.activiti.cloud.services.test.identity.keycloak.interceptor"})
     @EnableBinding(EngineEventsMessageProducer.EngineEvents.class)
     static class Application {
         // Nothing
@@ -137,6 +135,7 @@ public class ActivitiGraphQLStarterIT {
     public void setUp() {
         keycloakTokenProducer.setKeycloakTestUser(TESTADMIN);
         authHeaders = keycloakTokenProducer.authorizationHeaders();
+        authHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
     }
     
     protected URI getUrl(String path) throws URISyntaxException {
@@ -1044,9 +1043,9 @@ public class ActivitiGraphQLStarterIT {
         
         ResponseEntity<Result> entity = rest.postForEntity(GRAPHQL_URL, new HttpEntity<>(query,authHeaders), Result.class);
 
-        assertThat(HttpStatus.OK)
+        assertThat(entity.getStatusCode())
             .describedAs(entity.toString())
-            .isEqualTo(entity.getStatusCode());
+            .isEqualTo(HttpStatus.OK);
 
         Result result = entity.getBody();
 
@@ -1099,9 +1098,9 @@ public class ActivitiGraphQLStarterIT {
 
         ResponseEntity<Result> entity = rest.postForEntity(GRAPHQL_URL, new HttpEntity<>(query, authHeaders), Result.class);
 
-        assertThat(HttpStatus.OK)
+        assertThat(entity.getStatusCode())
             .describedAs(entity.toString())
-            .isEqualTo(entity.getStatusCode());
+            .isEqualTo(HttpStatus.OK);
 
         Result result = entity.getBody();
 
@@ -1147,9 +1146,9 @@ public class ActivitiGraphQLStarterIT {
 
         ResponseEntity<Result> entity = rest.postForEntity(GRAPHQL_URL, new HttpEntity<>(query, authHeaders), Result.class);
 
-        assertThat(HttpStatus.OK)
+        assertThat(entity.getStatusCode())
             .describedAs(entity.toString())
-            .isEqualTo(entity.getStatusCode());
+            .isEqualTo(HttpStatus.OK);
 
         Result result = entity.getBody();
 
@@ -1181,9 +1180,9 @@ public class ActivitiGraphQLStarterIT {
 
         ResponseEntity<Result> entity = rest.postForEntity(GRAPHQL_URL, new HttpEntity<>(query, authHeaders), Result.class);
 
-        assertThat(HttpStatus.OK)
+        assertThat(entity.getStatusCode())
             .describedAs(entity.toString())
-            .isEqualTo(entity.getStatusCode());
+            .isEqualTo(HttpStatus.OK);
 
         Result result = entity.getBody();
 
@@ -1205,9 +1204,9 @@ public class ActivitiGraphQLStarterIT {
 
         ResponseEntity<Result> entity = rest.postForEntity(GRAPHQL_URL, new HttpEntity<>(query, authHeaders), Result.class);
 
-        assertThat(HttpStatus.OK)
+        assertThat(entity.getStatusCode())
             .describedAs(entity.toString())
-            .isEqualTo(entity.getStatusCode());
+            .isEqualTo(HttpStatus.OK);
 
         Result result = entity.getBody();
 

--- a/starter/src/test/java/org/activiti/cloud/notifications/graphql/test/EngineEventsMessageProducer.java
+++ b/starter/src/test/java/org/activiti/cloud/notifications/graphql/test/EngineEventsMessageProducer.java
@@ -15,12 +15,6 @@
  */
 package org.activiti.cloud.notifications.graphql.test;
 
-import java.io.IOException;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -36,6 +30,12 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.context.Context;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
 @EnableBinding(EngineEventsMessageProducer.EngineEvents.class)


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/activiti-cloud-service-common/pull/207 and https://github.com/Activiti/activiti-cloud-query-service/pull/307

Fixes https://github.com/Activiti/Activiti/issues/1399